### PR TITLE
prevent loading of all commerce entities to prepare filter options

### DIFF
--- a/src/Plugin/pagedesigner/Handler/AdaptableBlock.php
+++ b/src/Plugin/pagedesigner/Handler/AdaptableBlock.php
@@ -136,7 +136,7 @@ class AdaptableBlock extends PluginBase implements HandlerPluginInterface {
   /**
    * {@inheritdoc}
    */
-  public function getContent(Element $entity, array &$list = []) {
+  public function getContent(Element $entity, array &$list = [], $published = true) {
   }
 
   /**

--- a/src/Plugin/pagedesigner_block_adaptable/Filter/Numeric.php
+++ b/src/Plugin/pagedesigner_block_adaptable/Filter/Numeric.php
@@ -114,7 +114,7 @@ class Numeric extends FilterPluginBase {
         $database = \Drupal::database();
         $table_name = $entity_type . '_field_data';
         $query = $database->select($table_name, 'u');
-        if ($entity_type == "commerce_produc") {
+        if ($entity_type == "commerce_product") {
           $query->fields('u', ['product_id', 'title']);
           $result = $query->execute();
           foreach ($result as $record) {

--- a/src/Plugin/pagedesigner_block_adaptable/Filter/Numeric.php
+++ b/src/Plugin/pagedesigner_block_adaptable/Filter/Numeric.php
@@ -108,23 +108,37 @@ class Numeric extends FilterPluginBase {
     elseif (substr($filter['field'], -3) == '_id') {
       $entity_type = $filter['entity_type'];
       $label = substr($filter['field'], 0, -3);
-      $items = \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple();
       $options = [];
       $values = [];
-      foreach ($items as $item) {
-        if ($item != NULL) {
-          $options[$item->id()] = $item->label();
-          // Support for the commerce variation entity type.
-          if ($entity_type == 'commerce_product_variation') {
-            /** @var \Drupal\commerce_product\Entity\ProductVariation $variation */
-            $variation = ProductVariation::load($item->id());
-            // If it is a variation, get the label and SKU from the variation
-            // instead of only the product label, since it will be the same for
-            // each variation.
-            $options[$item->id()] = $variation->label() . ' - ' . $variation->getSku();
+      if (strpos($entity_type, 'commerce_product') == 0) {
+        $database = \Drupal::database();
+        $table_name = $entity_type . '_field_data';
+        $query = $database->select($table_name, 'u');
+        if ($entity_type == "commerce_produc") {
+          $query->fields('u', ['product_id', 'title']);
+          $result = $query->execute();
+          foreach ($result as $record) {
+            $options[$record->product_id] = $record->title;
+          }
+        }
+        if ($entity_type == "commerce_product_variation") {
+          $query_fields = ['variation_id', 'title', 'sku'];
+          $query->fields('u', ['variation_id', 'title', 'sku']);
+          $result = $query->execute();
+          foreach ($result as $record) {
+            $options[$record->variation_id] = $record->title . ' - ' . $record->sku;
           }
         }
       }
+      else {
+        $items = \Drupal::entityTypeManager()->getStorage($entity_type)->loadMultiple();
+        foreach ($items as $item) {
+          if ($item != NULL) {
+            $options[$item->id()] = $item->label();
+          }
+        }
+      }
+      
       return [
         'description' => 'Choose ' . $label,
         'label' => $filter['expose']['label'],


### PR DESCRIPTION
Hi Philippe
After importing all Products and Variations from Easyjob the Top Events Website crashed.
We found out it was due to the numeric filter loading all the entities in order to prepare the filter options.
While I think this filter make no sense (select a product inside a 5000 products list!), we should still prepare a workaround for it in case it is used.
In this branch I suggest to replace the loading of entities with a simple query to the db tables. It is currently only for commerce products and commerce variations, it may be necessary to extend it to all entities.
What do you think?